### PR TITLE
Resolve static properties (#90)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /stubs
 /.phpbench
 .phpunit.result.cache
+/.vscode

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "phpstan/phpstan": "~0.12.0",
         "phpunit/phpunit": "^9.0",
         "symfony/filesystem": "^4.3 || ^5.0",
-        "phpspec/prophecy-phpunit": "^2.0"
+        "phpspec/prophecy-phpunit": "^2.0",
+        "symfony/var-dumper": "^5.2"
     },
     "extra": {
         "branch-alias": {

--- a/lib/Core/Inference/MemberTypeResolver.php
+++ b/lib/Core/Inference/MemberTypeResolver.php
@@ -36,6 +36,9 @@ class MemberTypeResolver
 
     public function propertyType(Type $containerType, SymbolContext $info, string $name): SymbolContext
     {
+        if (mb_substr($name, 0, 1) == '$') {
+            $name = mb_substr($name, 1);
+        }
         return $this->memberType(self::TYPE_PROPERTIES, $containerType, $info, $name);
     }
 

--- a/lib/Core/Inference/SymbolContextResolver.php
+++ b/lib/Core/Inference/SymbolContextResolver.php
@@ -98,6 +98,9 @@ class SymbolContextResolver
     public function resolveNode(Frame $frame, $node): SymbolContext
     {
         try {
+            if ($node instanceof ParserVariable && $node->parent instanceof ScopedPropertyAccessExpression) {
+                return $this->_resolveNode($frame, $node->parent);
+            }
             return $this->_resolveNode($frame, $node);
         } catch (CouldNotResolveNode $couldNotResolveNode) {
             return SymbolContext::none()
@@ -668,7 +671,7 @@ class SymbolContextResolver
         ) {
             $memberType = Symbol::CONSTANT;
         }
-
+        
         $information = $this->symbolFactory->context(
             $memberName,
             $node->getStart(),

--- a/phpbench.json
+++ b/phpbench.json
@@ -9,7 +9,8 @@
     "php_config": {
         "extension": [
             "tokenizer",
-            "json"
+            "json",
+            "iconv"
         ],
         "error_reporting": -1,
         "memory_limit": -1

--- a/tests/Integration/Core/Inference/SymbolContextResolverTest.php
+++ b/tests/Integration/Core/Inference/SymbolContextResolverTest.php
@@ -647,6 +647,48 @@ EOT
                 , [], ['type' => 'string'],
                 ];
 
+        yield 'Static property access' => [
+                    <<<'EOT'
+<?php
+
+Foobar::$my<>Property;
+
+class Foobar
+{
+    /** @var string */
+    public static $myProperty = 'hello';
+}
+EOT
+                    , [], [
+                        'type' => 'string',
+                        'symbol_type' => Symbol::PROPERTY,
+                        'symbol_name' => 'myProperty',
+                        'container_type' => 'Foobar',
+                    ],
+                ];
+        
+        yield 'Static property access 2' => [
+                    <<<'EOT'
+<?php
+
+class Foobar
+{
+    /** @var string */
+    public static $myProperty = 'hello';
+
+    function m() {
+        self::$my<>Property = 5;
+    }
+}
+EOT
+                    , [], [
+                        'type' => 'string',
+                        'symbol_type' => Symbol::PROPERTY,
+                        'symbol_name' => 'myProperty',
+                        'container_type' => 'Foobar',
+                    ],
+                ];
+
         yield 'Member access with variable' => [
                 <<<'EOT'
 <?php


### PR DESCRIPTION
* Fix switched start and end positions in SymbolContextResolver.

* Resolve static properties

* Resolve static properties

* --

* Add iconv

Co-authored-by: Vladislav Kosev <vladislav.kosev@clevertogether.com>